### PR TITLE
Fix chrM handling

### DIFF
--- a/gwaspy/preimp_qc/plots.py
+++ b/gwaspy/preimp_qc/plots.py
@@ -102,7 +102,7 @@ def manhattan_plot(pvals, significance_threshold: float = -np.log10(5E-08), titl
     data.columns = ['locus', 'p', 'chromosome', 'position'] # rename columns
     data['position'] = data['position'].astype(int)
     data['chromosome'] = data['chromosome'].str.replace('chr', '')
-    data['chromosome'].replace({"X": 23, "Y": 24, "MT": 25}, inplace=True)
+    data['chromosome'].replace({"X": 23, "Y": 24, "MT": 25, "M":25}, inplace=True)
     data['chromosome'] = data['chromosome'].astype(int)
     data.dropna(subset=['p'], inplace=True)  # drop NAs as log10(val) won't work
 

--- a/gwaspy/preimp_qc/preimp_qc.py
+++ b/gwaspy/preimp_qc/preimp_qc.py
@@ -111,10 +111,18 @@ def preimp_qc(input_type: str = None, dirname: str = None, basename: str = None,
         data_type = 'no-pheno'
 
     chroms = mt.aggregate_rows(hl.agg.collect_as_set(mt.locus.contig))
-    if ('chrX' or 'chrY' or 'chrMT') in chroms:
-        chromx, chromy, chrommt = 'chrX', 'chrY', 'chrMT'
+        if ('chrX' or 'chrY' or 'chrMT' or 'chrM') in chroms:
+        chromx, chromy = 'chrX', 'chrY'
+        if ('chrMT') in chroms:
+            chrommt = 'MT'
+        else:
+            chrommt = 'M'
     else:
-        chromx, chromy, chrommt = 'X', 'Y', 'MT'
+        chromx, chromy = 'X', 'Y'
+        if ('chrMT') in chroms:
+            chrommt = 'MT'
+        else:
+            chrommt = 'M'
 
     # we need to compute call rate for chr1-23 and chrY separately since females have no chrY
     mt = mt.annotate_entries(

--- a/gwaspy/preimp_qc/preimp_qc.py
+++ b/gwaspy/preimp_qc/preimp_qc.py
@@ -111,7 +111,7 @@ def preimp_qc(input_type: str = None, dirname: str = None, basename: str = None,
         data_type = 'no-pheno'
 
     chroms = mt.aggregate_rows(hl.agg.collect_as_set(mt.locus.contig))
-        if ('chrX' or 'chrY' or 'chrMT' or 'chrM') in chroms:
+    if ('chrX' or 'chrY' or 'chrMT' or 'chrM') in chroms:
         chromx, chromy = 'chrX', 'chrY'
         if ('chrMT') in chroms:
             chrommt = 'MT'


### PR DESCRIPTION
Some builds have different chrMT coding (e.g. chrM). Zan's solution fixes this for both `preimpc_qc` and plotting